### PR TITLE
Add Inch CI to test documentation quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ before_script:
   - . bin/ci before_script
 script:
   - . bin/ci script
+after_script:
+  - mix deps.get --only docs
+  - MIX_ENV=docs mix inch.report
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Sentix
-[![Build Status](https://img.shields.io/travis/zackehh/sentix.svg)](https://travis-ci.org/zackehh/sentix) [![Coverage Status](https://img.shields.io/coveralls/zackehh/sentix.svg)](https://coveralls.io/github/zackehh/sentix) [![Hex.pm Version](https://img.shields.io/hexpm/v/sentix.svg)](https://hex.pm/packages/sentix) [![Documentation](https://img.shields.io/badge/docs-latest-yellowgreen.svg)](https://hexdocs.pm/sentix/)
+[![Build Status](https://img.shields.io/travis/zackehh/sentix.svg)](https://travis-ci.org/zackehh/sentix) [![Coverage Status](https://img.shields.io/coveralls/zackehh/sentix.svg)](https://coveralls.io/github/zackehh/sentix) [![Inline docs](http://inch-ci.org/github/zackehh/sentix.svg)](http://inch-ci.org/github/zackehh/sentix) [![Hex.pm Version](https://img.shields.io/hexpm/v/sentix.svg)](https://hex.pm/packages/sentix) [![Documentation](https://img.shields.io/badge/docs-latest-yellowgreen.svg)](https://hexdocs.pm/sentix/)
 
 Sentix is a file system watcher based on [fswatch](https://github.com/emcrisostomo/fswatch). It provides a stable port binding around `fswatch` (with configurable arguments) and translates the output to messages that are easy to work with from inside Elixir. Naturally, it goes without saying that you need `fswatch` installed to use this tool properly.
 

--- a/mix.exs
+++ b/mix.exs
@@ -65,6 +65,7 @@ defmodule Sentix.Mixfile do
       # Development dependencies
       { :credo,       "~> 0.4.5",  optional: true, only: [ :dev, :test ] },
       { :ex_doc,      "~> 0.12.0", optional: true, only: [ :dev, :test ] },
+      { :inch_ex,     "~> 0.5.4",  optional: true, only: [ :docs] },
       { :excoveralls, "~> 0.5.5",  optional: true, only: [ :dev, :test ] }
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,9 @@
   "exjsx": {:hex, :exjsx, "3.2.1", "1bc5bf1e4fd249104178f0885030bcd75a4526f4d2a1e976f4b428d347614f0f", [:mix], [{:jsx, "~> 2.8.0", [hex: :jsx, optional: false]}]},
   "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
+  "inch_ex": {:hex, :inch_ex, "0.5.5", "b63f57e281467bd3456461525fdbc9e158c8edbe603da6e3e4671befde796a3d", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
   "jsx": {:hex, :jsx, "2.8.0", "749bec6d205c694ae1786d62cea6cc45a390437e24835fd16d12d74f07097727", [:mix, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}
+  "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []}}


### PR DESCRIPTION
Add in Inch CI to ensure that documentation stays at a high quality. I'm not sure if Inch will pick up on the origin automatically or if `MIX_ENV=docs mix do deps.get, inchci.add` will need to be run on the origin repo.